### PR TITLE
Use socket timeouts when doing HTTPS requests.

### DIFF
--- a/ccuapi/__init__.py
+++ b/ccuapi/__init__.py
@@ -23,6 +23,7 @@ AKAMAI_PASSWORD = os.environ.get('AKAMAI_PASSWORD', None)
 AKAMAI_NOTIFY_EMAIL = os.environ.get('AKAMAI_NOTIFY_EMAIL', None)
 AKAMAI_API_HOST = os.environ.get('AKAMAI_API_HOST',
                                  'api.ccu.akamai.com')
+AKAMAI_HTTPS_TIMEOUT = os.environ.get('AKAMAI_HTTPS_TIMEOUT', 34)
 
 if not AKAMAI_USERNAME or not AKAMAI_PASSWORD:
     config = configparser.SafeConfigParser()  # pylint: disable=invalid-name

--- a/ccuapi/purge.py
+++ b/ccuapi/purge.py
@@ -4,7 +4,8 @@ CCU API.
 """
 
 from . import AKAMAI_USERNAME, AKAMAI_PASSWORD, AKAMAI_NOTIFY_EMAIL
-from . import AKAMAI_API_HOST
+from . import AKAMAI_API_HOST, AKAMAI_HTTPS_TIMEOUT
+
 
 from .exceptions import AkamaiPurgeTypeException
 from .exceptions import AkamaiCredentialException
@@ -31,12 +32,16 @@ class PurgeRequest(object):
                   verify argument to request.get() and requests,post()
                   functions. See Requests library documentation for more
                   information.
+    https_timeout - The https timeout setting while making API requests.
+                  (float or tuple) How long to wait for the server to send data
+                  before giving up, as a float, or a (connect timeout,
+                  read timeout) tuple.
     """
     # pylint: disable=too-many-arguments
     def __init__(self, username=AKAMAI_USERNAME, password=AKAMAI_PASSWORD,
                  email=AKAMAI_NOTIFY_EMAIL, options=None, urls=None,
                  kind=None, domain='production', api_host=None,
-                 certificate=True):
+                 certificate=True, https_timeout=None):
 
         # Start by validating input
         if kind not in ['arl', 'cpcode']:
@@ -63,6 +68,12 @@ class PurgeRequest(object):
             self.api_host = api_host
 
         self.certificate = certificate
+
+        if https_timeout is None:
+            self.https_timeout = AKAMAI_HTTPS_TIMEOUT
+        else:
+            self.https_timeout = https_timeout
+
 
         self.type = kind
         self.domain = domain
@@ -115,10 +126,12 @@ class PurgeRequest(object):
             payload = json.dumps(payload)
 
         if method == 'GET':
-            rsp = api_client.get(api_url, verify=self.certificate)
+            rsp = api_client.get(api_url, verify=self.certificate,
+                                 timeout=self.https_timeout)
         else:
             rsp = api_client.post(api_url, data=payload,
-                                  verify=self.certificate)
+                                  verify=self.certificate,
+                                  timeout=self.https_timeout)
 
         if rsp.status_code == 401:
             raise AkamaiAuthenticationException(


### PR DESCRIPTION
Make it possible to specify socket timeouts when making Akamai API requests over HTTPS.

This allows to handle the cases when the Akamai API host does not respond.

I have added this code when I noticed that Akamai API host would stop replying to HTTPS requests sometimes. Without the timeout the local process would indefinitely wait for the reply, thus requiring to kill it.